### PR TITLE
Disable automatic update requests

### DIFF
--- a/components/update/class.update.php
+++ b/components/update/class.update.php
@@ -41,6 +41,7 @@ class Update
 
     public function Init()
     {
+        return;
         $version = array();
         if (!file_exists(DATA ."/version.php")) {
             if (file_exists(BASE_PATH."/.git/HEAD")) {


### PR DESCRIPTION
Automatic update web request fails and adds a delay of roughly 30 seconds after the editor starts.

2020/02/05 06:51:56 [error] 677#677: *102 upstream timed out (110: Connection timed out) while reading response header from upstream, client: x.x.x.x, server: localhost, request: "GET /components/update/controller.php?action=init HTTP/1.0", upstream: "fastcgi://unix:/var/run/php/php7.2-fpm.sock", host: "xxx", referrer: "xxx"